### PR TITLE
Fix upper bound for Yampa dep in Cabal file

### DIFF
--- a/cuboid.cabal
+++ b/cuboid.cabal
@@ -29,4 +29,4 @@ Cabal-Version:      >= 1.6
 Executable cuboid
     Main-Is:            Main.hs
     Other-Modules:      Types, Utils, Config, Input, Update, Graphics
-    Build-Depends:      base >= 3 && < 5, Yampa, GLUT >= 2.3
+    Build-Depends:      base >= 3 && < 5, Yampa <= 0.12, GLUT >= 2.3


### PR DESCRIPTION
Sets Yampa's upper bound to 0.12 (Yampa 0.13 onwards breaks Cuboid by removing Vector3).

With this I was able to build using Cabal 3.4.0.0, GHC Version 8.2.2 (mingw32) and freeglut.dll (freeglut-MinGW-3.0.0-1) on Windows.